### PR TITLE
updating readme to build for py2/py3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features:
 _roku-dev-cli_ can be installed from the pypi repository using pip.
 
 ```shell
-pip install roku-dev-cli
+pip3 install roku-dev-cli
 ```
 
 # Usage
@@ -155,5 +155,7 @@ TODO: document use of mitmdump scripts
     pypi.org password:
 
     ```shell
-    python setup.py sdist upload
+    python3 setup.py sdist
+    python3 setup.py bdist_wheel --universal
+    twine upload dist/*
     ```


### PR DESCRIPTION
Updating the readme to encouraging installation using python3.  Also updating build process to build for both python 2 and python 3.  Eventually I think we should just support python 3 since it came out almost ten years ago.  