### PR TITLE
fix(perf): Don't use 100% of CPU for telnet proxy

### DIFF
--- a/roku_dev_cli/roku_dev_cli.py
+++ b/roku_dev_cli/roku_dev_cli.py
@@ -119,7 +119,8 @@ class ConsoleListener(threading.Thread):
                         if self.timestamp:
                             timestamp = datetime.datetime.now().strftime('%h %d, %Y %I:%M:%S%p')
                             line = bcolors.OKBLUE + "[" + timestamp + "] " + bcolors.ENDC + line
-                        print(line)
+                        if line:
+                            print(line)
                     #when exiting to the debugger, we are exiting the script too.
                     if text.rfind("Brightscript Debugger>") != -1:
                         print(bcolors.FAIL + "Press any key to exit" + bcolors.ENDC)

--- a/roku_dev_cli/roku_dev_cli.py
+++ b/roku_dev_cli/roku_dev_cli.py
@@ -108,7 +108,7 @@ class ConsoleListener(threading.Thread):
         try:
             self.session = telnetlib.Telnet(self.ip, self.port)
             while True:
-                text = self.session.read_very_eager()
+                text = self.session.read_until(b"\n", 1)
                 if text:
                     text = text.decode('utf-8')
                     #removes logs from previous sessions
@@ -233,7 +233,7 @@ class PollingListener(threading.Thread):
         try:
             self.session = telnetlib.Telnet(self.ip, self.port)
             while True:
-                text = self.session.read_very_eager()
+                text = self.session.read_until(b"\n")
                 if text:
                     poller = self.pollers[self.pollerIndex]
                     poller.process(text)


### PR DESCRIPTION
We currently use `read_very_eager` in a `while True:` loop, which means we attempt to loop as quickly as possible.  Now we'll wait for a newline or one second, whichever comes first.  Everyone's laptop fans will thank them.

Also ensures empty lines don't get printed, which has bothered me for a while now.